### PR TITLE
Add support for lambda validations

### DIFF
--- a/lib/rxhp/attribute_validator.rb
+++ b/lib/rxhp/attribute_validator.rb
@@ -169,6 +169,8 @@ module Rxhp
       else
         if value.is_a? Symbol
           (matcher === value.to_s) || (matcher === name_from_symbol(value))
+        elsif matcher.respond_to? :call
+          matcher.call(value)
         else
           matcher === value
         end


### PR DESCRIPTION
Adds matchers support for lambdas.

Example:

```
class StarRating < Rxhp::ComposableElement
  require_attribute(:rating => lambda { |rating| [0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5].include? rating }
  def compose
  end
end
```
