### PR TITLE
Make RXHP errors standard errors

### DIFF
--- a/lib/rxhp/error.rb
+++ b/lib/rxhp/error.rb
@@ -7,7 +7,7 @@ module Rxhp
   end
 
   # Base class for script errors from Rxhp.
-  class ScriptError < ::ScriptError
+  class ScriptError < ::StandardError
   end
 
   # Base class for element correctness errors from Rxhp.

--- a/spec/attribute_validator_spec.rb
+++ b/spec/attribute_validator_spec.rb
@@ -206,7 +206,7 @@ describe Rxhp::AttributeValidator do
       it 'should be a descendent of Rxhp::ScriptError' do
         ancestors = Rxhp::ValidationError.ancestors
         ancestors.should include Rxhp::ScriptError
-        ancestors.should include ::ScriptError
+        ancestors.should include ::StandardError
       end
     end
 


### PR DESCRIPTION
RXHP errors (and all custom errors) should subclass StandardError.

Was this what was originally intended?
