### PR TITLE
New option: skip validation for 5x rendering speed.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source :rubygems
 
+gemspec
+
 group :test do
   gem 'simplecov', '~> 0.5.4'
   gem 'rake', '~> 0.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,8 @@
+PATH
+  remote: .
+  specs:
+    rxhp (0.3.0)
+
 GEM
   remote: http://rubygems.org/
   specs:
@@ -28,5 +33,6 @@ DEPENDENCIES
   rake (~> 0.8)
   redcarpet (~> 1.0, >= 1.17.2)
   rspec (~> 2.8.0)
+  rxhp!
   simplecov (~> 0.5.4)
   yard (~> 0.7, >= 0.7.4)

--- a/benchmark.rb
+++ b/benchmark.rb
@@ -1,0 +1,55 @@
+#!/usr/bin/env ruby
+require 'benchmark'
+require 'rxhp'
+
+H = Rxhp::Html
+
+def make_document
+  H.html {
+    H.head
+    H.body(class: 'newsfeed', id: 'gibberish') {
+      100.times {
+        H.div(
+          class: 'story',
+          id: 'gibberish',
+          style: 'gibberish',
+          onclick: 'gibberish',
+          onmouseover: 'gibberish',
+        ) {
+          H.img(src: 'example.jpg', title: 'gibberish')
+          H.p 'gibberish'
+          10.times {
+            H.div(
+              class: 'comment',
+              id: 'gibberish',
+              style: 'gibberish',
+              onclick: 'gibberish',
+              onmouseover: 'gibberish',
+            ) {
+              H.img(src: 'profile.jpg', title: 'gibberish')
+              H.p 'gibberish'
+            }
+          }
+          H.form(action: 'example.php', method: 'post') {
+            H.textarea(name: 'gibberish', rows: 3, placeholder: 'gibberish')
+            H.input(type: 'submit', name: 'gibberish', value: 'gibberish')
+          }
+        }
+        H.hr
+      }
+    }
+  }
+end
+
+Benchmark.bm(20) do |bm|
+  n = Integer(ARGV.first || 10)
+  bm.report('make document') { Example = make_document }
+  ObjectSpace.garbage_collect
+  bm.report('rehearsal') { n.times { Example.render }}
+  ObjectSpace.garbage_collect
+  bm.report('default') { n.times { Example.render }}
+  ObjectSpace.garbage_collect
+  bm.report('pretty=false') { n.times { Example.render(pretty: false) }}
+  ObjectSpace.garbage_collect
+  bm.report('validate=false') { n.times { Example.render(validate: false) }}
+end

--- a/lib/rxhp/element.rb
+++ b/lib/rxhp/element.rb
@@ -95,6 +95,7 @@ module Rxhp
         :doctype => Rxhp::HTML_5,
         :depth => 0,
         :indent => 2,
+        :validate => true,
       }.merge(options)
     end
 

--- a/lib/rxhp/html_element.rb
+++ b/lib/rxhp/html_element.rb
@@ -52,8 +52,8 @@ module Rxhp
     # Pays attention to the formatter type, doctype, pretty print options,
     # etc. See {Element#render} for options.
     def render options = {}
-      validate!
       options = fill_options(options)
+      validate! if options[:validate]
 
       open = render_open_tag(options)
       inner = render_children(options)

--- a/rxhp.gemspec
+++ b/rxhp.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |s|
   s.name = 'rxhp'
-  s.version = '0.2.1'
+  s.version = '0.3.0'
   s.platform = Gem::Platform::RUBY
-  s.authors = ['Fred Emmott']
+  s.authors = `git shortlog -s | sort -r | cut -f2`.split($/)
   s.email = ['rxhp-gem@fredemmott.co.uk']
   s.homepage = 'https://github.com/fredemmott/rxhp'
   s.summary = %q<An object-oriented validating HTML template system>


### PR DESCRIPTION
@fredemmott happy Monday to you and thank you for bringing xhp to Ruby! :tada:

Over 80% of rendering time is spent in validation. This diff introduces a new option to disable validation which may speed up rendering by 3–10x depending on the number of attributes in the document.

I am working on a follow-up to remove the linear search from validation code, but wanted to get this less invasive change out first.

The benchmark document has about 2 attributes per element and shows a 5x speed up
```
~/code/repos/rxhp <3 bundle execute benchmark.rb
                           user     system      total        real
make document          0.610000   0.000000   0.610000 (  0.615297)
rehearsal              5.000000   0.010000   5.010000 (  5.014030)
default                5.050000   0.010000   5.060000 (  5.070135)
pretty=false           4.950000   0.010000   4.960000 (  4.962137)
validate=false         1.000000   0.000000   1.000000 (  0.997756)
```

Also, adds `gemspec` to gemfile to enable import in benchmark file.
Also, pulls author names from github logs. Are you cool with that?

Test plan
- Run `bundle execute benchmark.rb` and expect to see 5x speedup.
- Run `bundle execute rspec` and expect to pass.

